### PR TITLE
Fix save data loss: flush filesystem to IndexedDB on tab close and at intervals

### DIFF
--- a/lua/normalize1.lua
+++ b/lua/normalize1.lua
@@ -54,6 +54,13 @@ function love.js.eval(cmd)
   return output
 end
 
+-- Flush save data to IndexedDB immediately.
+-- Call this after love.filesystem.write() to ensure data is persisted
+-- without waiting for the automatic sync interval.
+function love.js.savesync()
+  love.js.eval('_idbSync()')
+end
+
 --if os then
 --  os.execute = love.js.eval
 --end

--- a/player.js
+++ b/player.js
@@ -382,7 +382,12 @@ SOFTWARE.
         if (err) console.error('[love.js] IDB sync error:', err);
       });
   };
-  setInterval(window._idbSync, 10000);
+
+  // Crash/force-kill safety net: pagehide and visibilitychange don't always
+  // fire before the browser tears down the page, so sync on a regular cadence
+  // as well. Cancelled in onbeforeunload for clean normal exits.
+  var _idbSyncTimer = setInterval(window._idbSync, 10000);
+
   window.addEventListener('pagehide', function() {
     // A keepalive fetch signals the browser to keep this context alive long
     // enough for the async IndexedDB write to complete before tab teardown.
@@ -430,6 +435,7 @@ SOFTWARE.
   // Tries to sync the file-system when navigating away.
   // Note: async operations may be cut short here; pagehide is more reliable.
   window.onbeforeunload = function(event) {
+    clearInterval(_idbSyncTimer);
     window._idbSync();
     // todo: love.event.exit when navigating away
     Module.exit(0);

--- a/player.js
+++ b/player.js
@@ -372,6 +372,27 @@ SOFTWARE.
   
   Player.runLove();
 
+  // Flush the Emscripten in-memory filesystem to IndexedDB so that
+  // love.filesystem saves persist reliably across browser sessions.
+  // window.Module.FS is set inside runPkgs once love.js is loaded.
+  window._idbSync = function() {
+    var fs = window.Module && window.Module.FS;
+    if (fs && typeof fs.syncfs === 'function')
+      fs.syncfs(false, function(err) {
+        if (err) console.error('[love.js] IDB sync error:', err);
+      });
+  };
+  setInterval(window._idbSync, 10000);
+  window.addEventListener('pagehide', function() {
+    // A keepalive fetch signals the browser to keep this context alive long
+    // enough for the async IndexedDB write to complete before tab teardown.
+    try { fetch('', { method: 'POST', keepalive: true }); } catch (e) {}
+    window._idbSync();
+  });
+  document.addEventListener('visibilitychange', function() {
+    if (document.visibilityState === 'hidden') window._idbSync();
+  });
+
   // Handling errors
   window.onerror = function (msg) {
     console.error(msg);
@@ -406,9 +427,10 @@ SOFTWARE.
     }
   };
   
-  // Tries to sync the file-system when navigating away
-  // This is not reliable, since async operations are not allowed at this point
+  // Tries to sync the file-system when navigating away.
+  // Note: async operations may be cut short here; pagehide is more reliable.
   window.onbeforeunload = function(event) {
+    window._idbSync();
     // todo: love.event.exit when navigating away
     Module.exit(0);
   };

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,6 @@
 love.js allows you to run LÖVE 11.5 apps and games on the web.
 The 2dengine version of love.js can run .love files directly, without building or node.js.
 love.js is based on the previous work by Davidobot and Tanner Rogalsky using Emscripten.
-This fork adds reliable save data persistence by automatically syncing the Emscripten filesystem to IndexedDB on an interval and on page hide, and exposes `love.js.savesync()` so game code can trigger an immediate flush after a save operation.
 
 The source code is available on [GitHub](https://github.com/2dengine/love.js) and the documentation is hosted on [2dengine.com](https://2dengine.com/doc/lovejs.html)
 

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 love.js allows you to run LÖVE 11.5 apps and games on the web.
 The 2dengine version of love.js can run .love files directly, without building or node.js.
 love.js is based on the previous work by Davidobot and Tanner Rogalsky using Emscripten.
+This fork adds reliable save data persistence by automatically syncing the Emscripten filesystem to IndexedDB on an interval and on page hide, and exposes `love.js.savesync()` so game code can trigger an immediate flush after a save operation.
 
 The source code is available on [GitHub](https://github.com/2dengine/love.js) and the documentation is hosted on [2dengine.com](https://2dengine.com/doc/lovejs.html)
 


### PR DESCRIPTION
Problem: love.filesystem.write() lands in MEMFS (Emscripten's in-memory filesystem, volatile) and must be explicitly flushed to IndexedDB (the browser's persistent storage) via the async Module.FS.syncfs(). If the tab closes before that flush completes, saves are lost. 

To fix, player.js has 3 flush triggers added after boot:
pagehide event - most reliable signal for tab close; also sends a keepalive fetch to buy time for the async write
visibilitychange event - flushes when the page is backgrounded
setInterval every 10s - safety net for crashes/force-kills; cancelled in onbeforeunload on clean exits

normalize1.lua - adds love.js.savesync() to the Lua-side bridge so game code can request an explicit flush after a save. No-op on desktop.